### PR TITLE
feat: implement analytics/reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
         run: |
           pytest
         env:
-          TEST_DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test
+          DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,4 @@ jobs:
           pytest
         env:
           DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test
+          TEST_DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
         run: |
           pytest
         env:
-          DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test
+          TEST_DATABASE_URL: postgresql://hetalmangukia:postgres@localhost:5432/postgres_test

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 from api.routes.shorten import router as shorten_router
 from api.routes.redirect import router as redirect_router
+from api.routes.analytics import router as analytics_router
 
 api_router = APIRouter()
 
+api_router.include_router(analytics_router)
 api_router.include_router(shorten_router)
 api_router.include_router(redirect_router)

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -1,0 +1,33 @@
+from models import URLStatsResponse, URL, Visits
+from db import get_session
+from sqlmodel import Session, select
+from fastapi import Depends, APIRouter
+from sqlalchemy import func
+
+router = APIRouter()
+
+@router.get("/stats", response_model=list[URLStatsResponse])
+def get_top_links(number_of_links: int = 10, session: Session = Depends(get_session)):
+    urls = session.exec(
+        select(
+            URL.id,
+            URL.slug,
+            URL.long_url,
+            func.max(Visits.visit_time).label("last_visit"),
+            func.count(Visits.id).label("visit_count")
+        )
+        .join(Visits, Visits.url_id == URL.id, isouter=True)
+        .group_by(URL.id, URL.slug, URL.long_url, URL.created_at)
+        .order_by(func.count(Visits.id).desc())
+        .limit(number_of_links)
+    ).all()
+
+    return [
+        URLStatsResponse(
+            slug=url.slug,
+            long_url=url.long_url,
+            visits=url.visit_count,
+            last_visit=url.last_visit
+        )
+        for url in urls
+    ]

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -1,7 +1,7 @@
 from models import URLStatsResponse, URL, Visits
 from db import get_session
 from sqlmodel import Session, select
-from fastapi import Depends, APIRouter
+from fastapi import Depends, APIRouter, HTTPException
 from sqlalchemy import func
 
 router = APIRouter()
@@ -31,3 +31,29 @@ def get_top_links(number_of_links: int = 10, session: Session = Depends(get_sess
         )
         for url in urls
     ]
+
+
+@router.get("/stats/{slug}", response_model=URLStatsResponse)
+def get_url_stats(slug: str, session: Session = Depends(get_session)):
+    url = session.exec(
+        select(
+            URL.id,
+            URL.slug,
+            URL.long_url,
+            func.max(Visits.visit_time).label("last_visit"),
+            func.count(Visits.id).label("visit_count")
+        )
+        .where(URL.slug == slug)
+        .join(Visits, Visits.url_id == URL.id, isouter=True)
+        .group_by(URL.id, URL.slug, URL.long_url, URL.created_at)
+    ).first()
+
+    if not url:
+        raise HTTPException(status_code=404, detail=f"URL with the slug '{slug}' not found")
+
+    return URLStatsResponse(
+        slug=url.slug,
+        long_url=url.long_url,
+        visits=url.visit_count,
+        last_visit=url.last_visit
+    )

--- a/models.py
+++ b/models.py
@@ -20,3 +20,9 @@ class ShortenUrlRequest(BaseModel):
 class ShortenUrlResponse(BaseModel):
     short_url: str
     slug: str
+
+class URLStatsResponse(BaseModel):
+    slug: str
+    long_url: str
+    visits: int
+    last_visit: datetime | None

--- a/tests/test_url_analytics.py
+++ b/tests/test_url_analytics.py
@@ -56,3 +56,44 @@ def test_url_analytics(number_of_links):
                 "last_visit": None
             }
         ]
+
+
+@pytest.mark.parametrize("get_analytics_for_first_url", [True, False])
+def test_get_url_stats(get_analytics_for_first_url):
+    clear_test_db()
+    # create two URLs in the database and visit the second one
+    with Session(test_engine) as session:
+        long_url_1 = "https://example.com"
+        slug_1 = "test-slug"
+        url_1 = URL(long_url=long_url_1, slug=slug_1)
+        
+        long_url_2 = "https://example.com/blee/blah"
+        slug_2 = "test-slug-2"
+        url_2 = URL(long_url=long_url_2, slug=slug_2)
+
+        session.add_all([url_1, url_2])
+        session.commit()
+
+        visit = Visits(url_id=url_2.id)
+        session.add(visit)
+        session.commit()
+        session.refresh(visit)
+
+    request_url = f"/stats/{slug_1}" if get_analytics_for_first_url else f"/stats/{slug_2}"
+    response = client.get(request_url)
+    assert response.status_code == 200
+
+    if get_analytics_for_first_url:
+        assert response.json() == {
+            "slug": slug_1,
+            "long_url": long_url_1,
+            "visits": 0,
+            "last_visit": None
+        }
+    else:
+        assert response.json() == {
+            "slug": slug_2,
+            "long_url": long_url_2,
+            "visits": 1,
+            "last_visit": visit.visit_time.isoformat()
+        }

--- a/tests/test_url_analytics.py
+++ b/tests/test_url_analytics.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine, select
+from main import app
+from db import get_session
+from models import URL, Visits
+from tests.utils import clear_test_db, client, test_engine
+from datetime import datetime
+import pytest
+
+@pytest.mark.parametrize("number_of_links", [None, 1])
+def test_url_analytics(number_of_links):
+    clear_test_db()
+    # create two URLs in the database and visit the second one
+    with Session(test_engine) as session:
+        long_url_1 = "https://example.com"
+        slug_1 = "test-slug"
+        url_1 = URL(long_url=long_url_1, slug=slug_1)
+        
+        long_url_2 = "https://example.com/blee/blah"
+        slug_2 = "test-slug-2"
+        url_2 = URL(long_url=long_url_2, slug=slug_2)
+
+        session.add_all([url_1, url_2])
+        session.commit()
+
+        visit = Visits(url_id=url_2.id)
+        session.add(visit)
+        session.commit()
+        session.refresh(visit)
+
+    request_url = f"/stats?number_of_links={number_of_links}" if number_of_links else "/stats"
+    response = client.get(request_url)
+    assert response.status_code == 200
+
+    if number_of_links:
+        assert response.json() == [
+            {
+                "slug": slug_2,
+                "long_url": long_url_2,
+                "visits": 1,
+                "last_visit": visit.visit_time.isoformat()
+            }
+        ]
+    else:
+        assert response.json() == [
+            {
+                "slug": slug_2,
+                "long_url": long_url_2,
+                "visits": 1,
+                "last_visit": visit.visit_time.isoformat()
+            },
+            {
+                "slug": slug_1,
+                "long_url": long_url_1,
+                "visits": 0,
+                "last_visit": None
+            }
+        ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,10 +8,10 @@ import os
 
 load_dotenv(".env.test")
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
 
 test_engine = create_engine(
-    DATABASE_URL,
+    TEST_DATABASE_URL,
     echo=True
 )
 SQLModel.metadata.create_all(test_engine)


### PR DESCRIPTION
### Description
- This PR introduces an analytics endpoint that provides insights into the most visited shortened URLs and more details of specified URL slug in the system.
- GET `/stats`
   - Returns top `number_of_links` (default: 10), ordered by visit count (descending).
   ```
   [
      {
          "slug": "abcd12",
          "long_url": "https://www.example.com/...",
          "visits": 42,
          "last_visit": "2025-12-01T13:00:00Z"
        },
      {
          "slug": "efgh34",
          "long_url": "https://www.example.com/other/long/url",
          "visits": 0,
          "last_visit": null
        }
     ]
   ```
- GET `/stats/{slug}`
   - Returns analytics of the slug specified
   ```
      {
          "slug": "abcd12",
          "long_url": "https://www.example.com/...",
          "visits": 42,
          "last_visit": "2025-12-01T13:00:00Z"
        }
   ```
